### PR TITLE
(fix): `Guarantor` namespace and type conflict

### DIFF
--- a/src/Candid.Net/Encounters/V4/Types/Encounter.cs
+++ b/src/Candid.Net/Encounters/V4/Types/Encounter.cs
@@ -54,7 +54,7 @@ public record Encounter
     /// Personal and contact info for the guarantor of the patient responsibility.
     /// </summary>
     [JsonPropertyName("guarantor")]
-    public Guarantor? Guarantor { get; init; }
+    public Guarantor.V1.Guarantor? Guarantor { get; init; }
 
     /// <summary>
     /// The billing provider is the provider or business entity submitting the claim. Billing provider may be, but is not necessarily, the same person/NPI as the rendering provider. From a payer's perspective, this represents the person or entity being reimbursed. When a contract exists with the target payer, the billing provider should be the entity contracted with the payer. In some circumstances, this will be an individual provider. In that case, submit that provider's NPI and the tax ID (TIN) that the provider gave to the payer during contracting. In other cases, the billing entity will be a medical group. If so, submit the group NPI and the group's tax ID. Box 33 on the CMS-1500 claim form.


### PR DESCRIPTION
This PR manually fixes the `Guarantor` namespace and type conflict. The @fern-api team will track improving the generator to handle this edge case. 