### PR TITLE
fix: add `MedicationDispenseClient` to the top level

### DIFF
--- a/src/Candid.Net/Candid.Net.csproj
+++ b/src/Candid.Net/Candid.Net.csproj
@@ -7,7 +7,7 @@
         <NuGetAudit>false</NuGetAudit>
         <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
-        <Version>0.34.5</Version>
+        <Version>0.34.6</Version>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageProjectUrl>https://github.com/candidhealth/candid-csharp</PackageProjectUrl>
     </PropertyGroup>

--- a/src/Candid.Net/CandidClient.cs
+++ b/src/Candid.Net/CandidClient.cs
@@ -18,6 +18,7 @@ using Candid.Net.InsuranceAdjudications;
 using Candid.Net.InsurancePayments;
 using Candid.Net.InsuranceRefunds;
 using Candid.Net.Invoices;
+using Candid.Net.MedicationDispense;
 using Candid.Net.OrganizationProviders;
 using Candid.Net.OrganizationServiceFacilities;
 using Candid.Net.PatientPayments;
@@ -27,6 +28,7 @@ using Candid.Net.PreEncounter;
 using Candid.Net.ServiceLines;
 using Candid.Net.Tasks;
 using Candid.Net.WriteOffs;
+using Candid.Net.MedicationDispense;
 
 #nullable enable
 
@@ -95,6 +97,7 @@ public partial class CandidClient
         Individual = new IndividualClient(_client);
         ServiceFacility = new ServiceFacilityClient(_client);
         Tags = new TagsClient(_client);
+        MedicationDispense = new MedicationDispenseClient(_client);
     }
 
     public AuthClient Auth { get; init; }
@@ -166,4 +169,6 @@ public partial class CandidClient
     public ServiceFacilityClient ServiceFacility { get; init; }
 
     public TagsClient Tags { get; init; }
+    
+    public MedicationDispenseClient MedicationDispense { get; init; }
 }

--- a/src/Candid.Net/CandidClient.cs
+++ b/src/Candid.Net/CandidClient.cs
@@ -28,7 +28,6 @@ using Candid.Net.PreEncounter;
 using Candid.Net.ServiceLines;
 using Candid.Net.Tasks;
 using Candid.Net.WriteOffs;
-using Candid.Net.MedicationDispense;
 
 #nullable enable
 

--- a/src/Candid.Net/Core/Public/Version.cs
+++ b/src/Candid.Net/Core/Public/Version.cs
@@ -2,5 +2,5 @@ namespace Candid.Net;
 
 internal class Version
 {
-    public const string Current = "0.34.5";
+    public const string Current = "0.34.6";
 }


### PR DESCRIPTION
This is being manually added due to manually maintained oauth code (which will removed in our next C# release). 