### PR TITLE
chore: 0.34.8 release with oauth test and fix

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -17,6 +17,9 @@ src/Candid.Net.Test/Unit/Serialization/RateEntryTest.cs
 # Skip unit tests
 .github/workflows/ci.yml
 
+# Add Oauth Test
+src/Candid.Net.Test/TestClient.cs
+
 README.md
 
 

--- a/.fernignore
+++ b/.fernignore
@@ -3,6 +3,7 @@
 # Oauth
 src/Candid.Net/CandidClient.cs
 src/Candid.Net/Core/OAuthTokenProvider.cs
+src/Candid.Net/Core/ClientOptions.Clone.cs
 
 # Maintain compatibility with old client naming
 src/Candid.Net/Candid.cs

--- a/src/Candid.Net.Test/TestClient.cs
+++ b/src/Candid.Net.Test/TestClient.cs
@@ -1,3 +1,7 @@
+using Candid.Net.Auth.V2;
+using Candid.Net.Core;
+using Candid.Net.Encounters.V4;
+using Candid.Net.Exports.V3;
 using NUnit.Framework;
 
 #nullable enable
@@ -5,4 +9,19 @@ using NUnit.Framework;
 namespace Candid.Net.Test;
 
 [TestFixture]
-public class TestClient { }
+public class TestClient
+{
+    
+    [Test]
+    public async Task TestSerialization()
+    {
+        var client = new CandidClient(
+            "<CLIENT_ID>",
+            "<CLIENT_SECRET>",
+            new ClientOptions
+            {
+                Environment = CandidEnvironment.STAGING
+            });
+        await client.Encounters.V4.GetAllAsync(new GetAllEncountersRequest() { });
+    }
+}

--- a/src/Candid.Net/Candid.Net.csproj
+++ b/src/Candid.Net/Candid.Net.csproj
@@ -7,7 +7,7 @@
         <NuGetAudit>false</NuGetAudit>
         <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
-        <Version>0.34.7</Version>
+        <Version>0.34.8</Version>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageProjectUrl>https://github.com/candidhealth/candid-csharp</PackageProjectUrl>
     </PropertyGroup>

--- a/src/Candid.Net/CandidClient.cs
+++ b/src/Candid.Net/CandidClient.cs
@@ -57,7 +57,10 @@ public partial class CandidClient
             }
         }
 
-        var authRawClient = new RawClient(clientOptions);
+        var authRawClient = new RawClient(new ClientOptions
+        {
+            Environment = clientOptions.Environment,
+        });
         Auth = new AuthClient(authRawClient);
         
         var oAuthTokenProvider = new OAuthTokenProvider(clientId, clientSecret, Auth.V2);

--- a/src/Candid.Net/CandidClient.cs
+++ b/src/Candid.Net/CandidClient.cs
@@ -57,10 +57,7 @@ public partial class CandidClient
             }
         }
 
-        var authRawClient = new RawClient(new ClientOptions
-        {
-            Environment = clientOptions.Environment,
-        });
+        var authRawClient = new RawClient(clientOptions.Clone());
         Auth = new AuthClient(authRawClient);
         
         var oAuthTokenProvider = new OAuthTokenProvider(clientId, clientSecret, Auth.V2);

--- a/src/Candid.Net/Core/ClientOptions.Clone.cs
+++ b/src/Candid.Net/Core/ClientOptions.Clone.cs
@@ -1,0 +1,18 @@
+namespace Candid.Net.Core;
+
+#nullable enable
+
+public partial class ClientOptions
+{
+    internal ClientOptions Clone()
+    {
+        return new ClientOptions
+        {
+            Environment = Environment,
+            HttpClient = HttpClient,
+            MaxRetries = MaxRetries,
+            Timeout = Timeout,
+            Headers = new Headers(new Dictionary<string, HeaderValue>(Headers))
+        };
+    }
+}


### PR DESCRIPTION
This PR adds a `clone` method to `ClientOptions` which was previously removed