### PR TITLE
fix: Update dependencies to patch vulnerable transitive dependencies

### DIFF
--- a/src/Candid.Net.Test/Candid.Net.Test.csproj
+++ b/src/Candid.Net.Test/Candid.Net.Test.csproj
@@ -10,12 +10,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
-        <PackageReference Include="NUnit" Version="3.13.3"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.4.2"/>
-        <PackageReference Include="NUnit.Analyzers" Version="3.6.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="WireMock.Net" Version="1.5.60" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+        <PackageReference Include="coverlet.collector" Version="3.2.0" />
+        <PackageReference Include="WireMock.Net" Version="1.6.8" />
         <PackageReference Include="FluentAssertions.Json" Version="6.1.0" />
     </ItemGroup>
 

--- a/src/Candid.Net/Candid.Net.csproj
+++ b/src/Candid.Net/Candid.Net.csproj
@@ -10,7 +10,6 @@
         <Version>0.35.3</Version>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageProjectUrl>https://github.com/candidhealth/candid-csharp</PackageProjectUrl>
-        <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Candid.Net/Candid.Net.csproj
+++ b/src/Candid.Net/Candid.Net.csproj
@@ -10,6 +10,7 @@
         <Version>0.35.3</Version>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageProjectUrl>https://github.com/candidhealth/candid-csharp</PackageProjectUrl>
+        <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'">
@@ -35,6 +36,8 @@
         <PackageReference Include="OneOf" Version="3.0.271" />
         <PackageReference Include="OneOf.Extended" Version="3.0.271" />
         <PackageReference Include="System.Text.Json" Version="8.0.5" />
+        <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Candid.Net/Candid.Net.csproj
+++ b/src/Candid.Net/Candid.Net.csproj
@@ -1,4 +1,4 @@
- 
+
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
@@ -7,7 +7,7 @@
         <NuGetAudit>false</NuGetAudit>
         <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
-        <Version>0.35.2</Version>
+        <Version>0.35.3</Version>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageProjectUrl>https://github.com/candidhealth/candid-csharp</PackageProjectUrl>
     </PropertyGroup>
@@ -15,15 +15,15 @@
     <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'">
         <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
     </PropertyGroup>
-    
+
     <ItemGroup Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="Portable.System.DateTimeOnly" Version="8.0.1" />
     </ItemGroup>
-    
+
     <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
         <Reference Include="System.Net.Http" />
     </ItemGroup>
-    
+
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="PolySharp" Version="1.14.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -32,13 +32,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="OneOf" Version="3.0.263" />
-        <PackageReference Include="OneOf.Extended" Version="3.0.263" />
-        <PackageReference Include="System.Text.Json" Version="8.0.4" />
+        <PackageReference Include="OneOf" Version="3.0.271" />
+        <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="..\..\README.md" Pack="true" PackagePath=""/>
+        <None Include="..\..\README.md" Pack="true" PackagePath="" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Candid.Net/Core/Public/Version.cs
+++ b/src/Candid.Net/Core/Public/Version.cs
@@ -2,5 +2,5 @@ namespace Candid.Net;
 
 internal class Version
 {
-    public const string Current = "0.35.2";
+    public const string Current = "0.35.3";
 }


### PR DESCRIPTION
SDK version updated to 0.35.3

Update dependencies to patch vulnerable transitive dependencies
- OneOf 3.0.263 -> 3.0.271
- OneOf.Extended 3.0.263 -> 3.0.271
- WireMock.Net 1.5.60 -> 1.6.8
- System.Text.Json 8.0.4 -> 8.0.5

Promoted these transitive dependencies to direct dependencies to force the version to be above the patched version.
- System.Text.RegularExpressions
- System.Net.Http