### PR TITLE
Update ci.yml for upgraded fern generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,14 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@871f041373faaad213a635d9afb62905ec029bbb # v1
         with:
-          dotnet-version: 8.x
+          dotnet-version: 9.x
 
       - name: Install tools
         run: |
           dotnet tool restore
 
       - name: Build Release
-        run: dotnet build src -c Release /p:ContinuousIntegrationBuild=true
+        run: dotnet build src/Candid.Net/Candid.Net.csproj -c Release /p:ContinuousIntegrationBuild=true
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@871f041373faaad213a635d9afb62905ec029bbb # v1
         with:
-          dotnet-version: 8.x
+          dotnet-version: 9.x
 
       - name: Install tools
         run: |
@@ -59,13 +59,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@871f041373faaad213a635d9afb62905ec029bbb # v1
         with:
-          dotnet-version: 8.x
+          dotnet-version: 9.x
 
       - name: Publish
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
-          dotnet pack src -c Release
+          dotnet pack src/Candid.Net/Candid.Net.csproj -c Release
           dotnet nuget push src/Candid.Net/bin/Release/*.nupkg --api-key $NUGET_API_KEY --source "nuget.org"
           
   alert-on-failure:


### PR DESCRIPTION
Fixes CI failure: https://github.com/candidhealth/candid-csharp/actions/runs/28394673758/job/84130247915

Applies updates from Fern team in generator upgrade: https://github.com/candidhealth/candid-csharp/pull/38/changes#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f